### PR TITLE
Fix controller reconnection issues: ESP32 not responding to events after disconnecting and connecting back

### DIFF
--- a/src/ps3_l2cap.c
+++ b/src/ps3_l2cap.c
@@ -200,7 +200,7 @@ static void ps3_l2cap_connect_ind_cback (BD_ADDR  bd_addr, uint16_t l2cap_cid, u
     else if (psm == BT_PSM_HIDI)
         l2cap_id_hidi = l2cap_cid;
     else
-        ESP_LOGE(PS3_TAG, "[%s] Unexpected L2CAP ID: %d", __func__, l2cap_id);
+        ESP_LOGE(PS3_TAG, "[%s] Unexpected psm: %d", __func__, psm);
 
     /* Send connection pending response to the L2CAP layer. */
     L2CA_CONNECT_RSP (bd_addr, l2cap_id, l2cap_cid, L2CAP_CONN_PENDING, L2CAP_CONN_PENDING, NULL, NULL);

--- a/src/ps3_spp.c
+++ b/src/ps3_spp.c
@@ -149,4 +149,10 @@ static void ps3_spp_callback(esp_spp_cb_event_t event, esp_spp_cb_param_t *param
 
         esp_spp_start_srv(ESP_SPP_SEC_NONE,ESP_SPP_ROLE_SLAVE, 0, PS3_SERVER_NAME);
     }
+    else if (event == ESP_SPP_START_EVT) {
+        ESP_LOGI(PS3_TAG, "ESP_SPP_START_EVT");
+    }
+    else if (event == ESP_SPP_SRV_OPEN_EVT) {
+        ESP_LOGI(PS3_TAG, "ESP_SPP_SRV_OPEN_EVT");
+    }
 }


### PR DESCRIPTION
First problem is it was wrongly assumed that L2CAP channel ids are always assigned in the same order, ie. 0x40 for HIDC (PSM=17) and 0x41 for HIDI (PSM=19), but this is not always the case, eg. when you disconnect the controller and connect back, channel ids are allocated in reversed order: 0x41 for HIDC and 0x40 for HIDI, see trace:

```
W (17008) BT_HCI: hcif conn complete: hdl 0x81, st 0x0
I (17108) PS3_L2CAP: [ps3_l2cap_connect_ind_cback] bd_addr: 98:b6:de:15:bf:55
  l2cap_cid: 0x41
  psm: 17
  id: 1
I (17108) PS3_L2CAP: [ps3_l2cap_config_ind_cback] l2cap_cid: 0x41
  p_cfg->result: 0
  p_cfg->mtu_present: 1
  p_cfg->mtu: 800
I (17118) PS3_L2CAP: [ps3_l2cap_config_cfm_cback] l2cap_cid: 0x41
  p_cfg->result: 0
  received_psm_requests: 1
I (17128) PS3_L2CAP: [ps3_l2cap_connect_ind_cback] bd_addr: 98:b6:de:15:bf:55
  l2cap_cid: 0x40
  psm: 19
  id: 3
I (17148) PS3_L2CAP: [ps3_l2cap_config_ind_cback] l2cap_cid: 0x40
  p_cfg->result: 0
  p_cfg->mtu_present: 1
  p_cfg->mtu: 800
I (17148) PS3_L2CAP: [ps3_l2cap_config_cfm_cback] l2cap_cid: 0x40
  p_cfg->result: 0
  received_psm_requests: 2
I (17168) PS3_L2CAP: [ps3_l2cap_send_hid] sending command: success
```

Second problem is related to the above: it was assumed that connection was successful after configuration of L2CAP cid 0x41 was confirmed, but this assumption is wrong if channel ids are allocated in reversed order. This resulted in `ps3Enable` being called too early when the actual data channel is not yet set up and attempts to send HID commands produced the following error:

```
W (44297) BT_L2CAP: L2CAP - no CCB for L2CA_DataWrite, CID: 64
E (44307) PS3_L2CAP: [ps3_l2cap_send_hid] sending command: failed
```

Finally, some additional info/debug traces have been added to help diagnosing this.